### PR TITLE
feat: Tag 컴포넌트 표현 개선

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,23 +1,24 @@
+import { RectangleGroupIcon } from "@heroicons/react/24/outline";
+import classNames from "classnames";
+import { useAtomValue, useSetAtom } from "jotai";
 import type { NextPage } from "next";
-import { useCallback, useEffect, useMemo, useState } from "react";
 import { NextSeo } from "next-seo";
+import { useCallback, useMemo, useState } from "react";
+import { DragDropContext } from "react-beautiful-dnd";
+import { useDebounce } from "use-debounce";
 import tags from "~/assets/tags.json";
 import {
+  NSFWToggle,
+  ResultBar,
+  showNSFWAtom,
   Tag,
   TagCard,
-  ResultBar,
   updatePromptListAtom,
-  NSFWToggle,
-  showNSFWAtom,
   WithUnderbarToggle,
 } from "~/components";
-import { useDebounce } from "use-debounce";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { DragDropContext } from "react-beautiful-dnd";
-import { darkModeAtom, DarkModeToggle } from "./DarkModeToggle";
-import classNames from "classnames";
-import { CopyToggle } from "./CopyToggle";
 import { Tag as TagType, TagsData } from "~/types";
+import { CopyToggle } from "./CopyToggle";
+import { DarkModeToggle } from "./DarkModeToggle";
 
 export const Home: NextPage = () => {
   const [selectedGroup, setSelectedGroup] = useState<string>("");
@@ -163,6 +164,13 @@ export const Home: NextPage = () => {
                     key={text}
                     disabled={disabled}
                     selected={selectedGroup === text}
+                    unselectedLeft={
+                      <RectangleGroupIcon
+                        className="dark:text-white"
+                        width={20}
+                        height={20}
+                      />
+                    }
                     onSelect={() => onSelectGroup(text)}
                   />
                 ))}

--- a/src/components/NSFWToggle.tsx
+++ b/src/components/NSFWToggle.tsx
@@ -1,4 +1,4 @@
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { Button } from "./Button";
 

--- a/src/components/PromptToggle.tsx
+++ b/src/components/PromptToggle.tsx
@@ -1,4 +1,4 @@
-import { atom, useAtom } from "jotai";
+import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { Button } from "./Button";
 

--- a/src/components/ResultBar.tsx
+++ b/src/components/ResultBar.tsx
@@ -1,16 +1,15 @@
-import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+import { TrashIcon } from "@heroicons/react/24/solid";
+import classNames from "classnames";
 import { atom, useAtom, useAtomValue } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import { TrashIcon } from "@heroicons/react/24/solid";
-import { Tag } from "./Tag";
 import { useCallback } from "react";
-import classNames from "classnames";
+import { Draggable, Droppable } from "react-beautiful-dnd";
 import { toast } from "react-hot-toast";
 import { copyText, replaceText } from "~/utils";
-import { darkModeAtom } from "./DarkModeToggle";
 import { Button } from "./Button";
 import { copyAtom } from "./CopyToggle";
 import { withUnderbarAtom } from "./PromptToggle";
+import { Tag } from "./Tag";
 
 export const promptListAtom = atomWithStorage<
   { tag: string; pinned: boolean }[]

--- a/src/components/ResultBar.tsx
+++ b/src/components/ResultBar.tsx
@@ -1,3 +1,4 @@
+import { LockClosedIcon } from "@heroicons/react/24/outline";
 import { TrashIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { atom, useAtom, useAtomValue } from "jotai";
@@ -79,21 +80,24 @@ export const ResultBar = () => {
                     <Tag
                       key={key}
                       selected={item.pinned}
-                      left={() =>
-                        item.pinned ? (
-                          <></>
-                        ) : (
-                          <TrashIcon
-                            className="dark:text-white"
-                            width={18}
-                            height={18}
-                            onClick={() => {
-                              setPromptList((prev) =>
-                                prev.filter((_, index) => index !== key)
-                              );
-                            }}
-                          />
-                        )
+                      unselectedLeft={
+                        <TrashIcon
+                          className="dark:text-white"
+                          width={18}
+                          height={18}
+                          onClick={() => {
+                            setPromptList((prev) =>
+                              prev.filter((_, index) => index !== key)
+                            );
+                          }}
+                        />
+                      }
+                      selectedLeft={
+                        <LockClosedIcon
+                          className="dark:text-white"
+                          width={18}
+                          height={18}
+                        />
                       }
                       onSelect={() => {
                         if (copyEach) {

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon } from "@heroicons/react/24/outline";
+import { CheckIcon, TagIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import React, { forwardRef } from "react";
 
@@ -7,7 +7,8 @@ interface Props extends React.PropsWithoutRef<JSX.IntrinsicElements["div"]> {
   selected?: boolean;
   onSelect?: () => void;
   disabled?: boolean;
-  left?: () => JSX.Element;
+  selectedLeft?: React.ReactNode;
+  unselectedLeft?: React.ReactNode;
 }
 
 export const Tag = forwardRef<HTMLDivElement, Props>(
@@ -18,29 +19,14 @@ export const Tag = forwardRef<HTMLDivElement, Props>(
       disabled = false,
       onSelect,
       className,
-      left: Left,
+      selectedLeft,
+      unselectedLeft,
       ...props
     },
     ref
   ) => {
-    return (
-      <div
-        className={classNames(
-          "border shadow-sm rounded-full flex max-w-fit gap-x-1 items-center dark:bg-zinc-800 dark:border-gray-600 bg-white",
-          (Left || selected) && "pl-2",
-          !disabled &&
-            (selected
-              ? "border-primary-300"
-              : "border-base-light dark:border-gray-600"),
-          !disabled &&
-            "hover:bg-gray-100 dark:hover:bg-zinc-700 cursor-pointer",
-          className
-        )}
-        onClick={!disabled && selected ? onSelect : undefined}
-        ref={ref}
-        {...props}
-      >
-        {selected && (
+    const leftElement = selected
+      ? selectedLeft || (
           <CheckIcon
             width={20}
             height={20}
@@ -49,15 +35,39 @@ export const Tag = forwardRef<HTMLDivElement, Props>(
               disabled ? "dark:text-gray-200 text-gray-600" : "text-primary-600"
             )}
           />
+        )
+      : unselectedLeft || (
+          <TagIcon
+            width={20}
+            height={20}
+            className={classNames(
+              "block",
+              disabled ? "dark:text-gray-200 text-gray-600" : "dark:text-white"
+            )}
+          />
+        );
+    return (
+      <div
+        className={classNames(
+          "border shadow-sm rounded-full flex max-w-fit gap-x-1 items-center dark:bg-zinc-800 dark:border-gray-600 bg-white pl-2",
+          !disabled &&
+            (selected
+              ? "border-primary-300"
+              : "border-base-light dark:border-gray-600"),
+          !disabled &&
+            "hover:bg-gray-100 dark:hover:bg-zinc-700 cursor-pointer",
+          className
         )}
-        {Left && <Left />}
+        onClick={disabled ? undefined : onSelect}
+        ref={ref}
+        {...props}
+      >
+        {leftElement}
         <span
           className={classNames(
             disabled ? "text-gray-500" : "text-gray-800 dark:text-gray-200",
-            "py-0.5, pr-2",
-            !Left && !selected && "pl-2"
+            "py-0.5 pr-2"
           )}
-          onClick={!disabled && !selected ? onSelect : undefined}
         >
           {label}
         </span>

--- a/src/components/TagCard.tsx
+++ b/src/components/TagCard.tsx
@@ -1,4 +1,4 @@
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import toast from "react-hot-toast";
 import { copyText, replaceText } from "~/utils";
 import { copyAtom } from "./CopyToggle";


### PR DESCRIPTION
* 사용되지 않는 import 정리
* 체크 여부에 따라 width가 변경되어 레이아웃이 변경되어 유저 경험이 떨어지는 것을 개선
* Tag 컴포넌트를 selected 여부에 따라 좌측 icon을 지정할 수 있도록 확장
* ResultBar의 pinned 기능 직관성을 lock-closed 아이콘으로 개선